### PR TITLE
docs(blog): retitle v1.0 blog post and add announcement bar

### DIFF
--- a/blog/releases/1.0.md
+++ b/blog/releases/1.0.md
@@ -1,10 +1,9 @@
 ---
-slug: v1-release
-title: Release notes v1
-date: 2025-07-25
+title: Announcing ImageJS 1.0
+date: 2025-08-20
 ---
 
-We're excited to announce the release of a new major version of ImageJS.
+We're excited to announce the release of a new major version of ImageJS!
 This version brings TypeScript support and a more intuitive API while maintaining the powerful image processing capabilities you love.
 
 <!-- truncate -->
@@ -267,7 +266,7 @@ The following deprecated features have been removed:
 
 - `countAlphaPixel()` - Use custom pixel counting with [`getPixel()`](https://api.image-js.org/classes/index.Image.html#getpixel 'API link on getPixel').
 - `paintLabels()` and `roi.paint()` - Features have been removed due to dependency issues. We plan to add it back in future updates.
-- `warpingFourPoints()` - Use [`getPerspectiveWarpMatrix()`](../docs/Features/Geometry/Get%20Perspective%20Warp%20Matrix 'internal link on getPerspectiveWarp') + [`transform()`](release.md#transform) instead.
+- `warpingFourPoints()` - Use [`getPerspectiveWarpMatrix()`](../docs/Features/Geometry/Get%20Perspective%20Warp%20Matrix 'internal link on getPerspectiveWarp') + [`transform()`](#transform) instead.
 - 32-bit color depth support and `abs()` have been removed.
 - `CMYK` and `HSL` color models have been removed.
 - `paintMasks()` has been removed. Use [`paintMask()`](https://api.image-js.org/classes/index.Image.html#paintmask 'API link on paintMask')+ a `for` loop.

--- a/blog/releases/1.0.md
+++ b/blog/releases/1.0.md
@@ -149,8 +149,8 @@ The new `blackRois` and `whiteRois` properties provide more intuitive access to 
 
 For more information, please visit these tutorials:
 
-- [Image segmentation with `threshold()` and `fromMask()`](../../docs/Tutorials/Image%20segmentation%20with%20threshold.md)
-- [Image segmentation with `watershed()`](../../docs/Tutorials/Image%20segmentation%20with%20watershed.md)
+- [Image segmentation with `threshold()` and `fromMask()`](../../docs/Tutorials/Image%20segmentation%20with%20threshold)
+- [Image segmentation with `watershed()`](../../docs/Tutorials/Image%20segmentation%20with%20watershed)
 
 ### Sobel and Scharr filters
 
@@ -266,7 +266,7 @@ The following deprecated features have been removed:
 
 - `countAlphaPixel()` - Use custom pixel counting with [`getPixel()`](https://api.image-js.org/classes/index.Image.html#getpixel 'API link on getPixel').
 - `paintLabels()` and `roi.paint()` - Features have been removed due to dependency issues. We plan to add it back in future updates.
-- `warpingFourPoints()` - Use [`getPerspectiveWarpMatrix()`](../../docs/Features/Geometry/Get%20Perspective%20Warp%20Matrix.md 'internal link on getPerspectiveWarp') + [`transform()`](#transform) instead.
+- `warpingFourPoints()` - Use [`getPerspectiveWarpMatrix()`](../../docs/Features/Geometry/Get%20Perspective%20Warp%20Matrix 'internal link on getPerspectiveWarp') + [`transform()`](#transform) instead.
 - 32-bit color depth support and `abs()` have been removed.
 - `CMYK` and `HSL` color models have been removed.
 - `paintMasks()` has been removed. Use [`paintMask()`](https://api.image-js.org/classes/index.Image.html#paintmask 'API link on paintMask')+ a `for` loop.
@@ -303,7 +303,7 @@ const matrix = getPerspectiveWarp(sourcePoints);
 const warped = img.transform(matrix);
 ```
 
-For more details, [visit our tutorial](../../docs/Tutorials/Applying%20transform%20function%20on%20images.md 'internal link on transform function tutorial') on how image transformations work how they can be used.
+For more details, [visit our tutorial](../../docs/Tutorials/Applying%20transform%20function%20on%20images 'internal link on transform function tutorial') on how image transformations work how they can be used.
 
 ### Bicubic interpolation
 
@@ -323,11 +323,11 @@ const resized = img.resize(800, 600, { interpolation: 'bicubic' });
 const prewitt = img.derivative({ filter: 'prewitt' });
 ```
 
-**Use cases**: Object detection, image segmentation, feature extraction. You can [learn more about it here](../../docs/Features/Morphology/Morphological%20Gradient.md 'internal link on morphological gradient').
+**Use cases**: Object detection, image segmentation, feature extraction. You can [learn more about it here](../../docs/Features/Morphology/Morphological%20Gradient 'internal link on morphological gradient').
 
 ### Migration from deprecated methods
 
-`warpingFourPoints()` has been removed. Now you have [`getPerspectiveWarp()`](../../docs/Features/Geometry/Get%20Perspective%20Warp%20Matrix.md 'internal link on perspective warp') that returns a matrix that can be applied on the image of interest in a new `transform()`.
+`warpingFourPoints()` has been removed. Now you have [`getPerspectiveWarp()`](../../docs/Features/Geometry/Get%20Perspective%20Warp%20Matrix 'internal link on perspective warp') that returns a matrix that can be applied on the image of interest in a new `transform()`.
 
 ```ts
 // Before
@@ -338,7 +338,7 @@ const matrix = getPerspectiveWarp(corners);
 const warped = img.transform(matrix);
 ```
 
-**Use cases**: Rectification of a perspective angle of an image. You can learn more about it [here](../../docs/Features/Geometry/Get%20Perspective%20Warp%20Matrix.md 'internal link on perspective warp').
+**Use cases**: Rectification of a perspective angle of an image. You can learn more about it [here](../../docs/Features/Geometry/Get%20Perspective%20Warp%20Matrix 'internal link on perspective warp').
 
 ### `merge()`
 

--- a/blog/releases/1.0.md
+++ b/blog/releases/1.0.md
@@ -149,8 +149,8 @@ The new `blackRois` and `whiteRois` properties provide more intuitive access to 
 
 For more information, please visit these tutorials:
 
-- [Image segmentation with `threshold()` and `fromMask()`](../docs/Tutorials/Image%20segmentation%20with%20threshold)
-- [Image segmentation with `watershed()`](../docs/Tutorials/Image%20segmentation%20with%20watershed)
+- [Image segmentation with `threshold()` and `fromMask()`](../../docs/Tutorials/Image%20segmentation%20with%20threshold.md)
+- [Image segmentation with `watershed()`](../../docs/Tutorials/Image%20segmentation%20with%20watershed.md)
 
 ### Sobel and Scharr filters
 
@@ -266,7 +266,7 @@ The following deprecated features have been removed:
 
 - `countAlphaPixel()` - Use custom pixel counting with [`getPixel()`](https://api.image-js.org/classes/index.Image.html#getpixel 'API link on getPixel').
 - `paintLabels()` and `roi.paint()` - Features have been removed due to dependency issues. We plan to add it back in future updates.
-- `warpingFourPoints()` - Use [`getPerspectiveWarpMatrix()`](../docs/Features/Geometry/Get%20Perspective%20Warp%20Matrix 'internal link on getPerspectiveWarp') + [`transform()`](#transform) instead.
+- `warpingFourPoints()` - Use [`getPerspectiveWarpMatrix()`](../../docs/Features/Geometry/Get%20Perspective%20Warp%20Matrix.md 'internal link on getPerspectiveWarp') + [`transform()`](#transform) instead.
 - 32-bit color depth support and `abs()` have been removed.
 - `CMYK` and `HSL` color models have been removed.
 - `paintMasks()` has been removed. Use [`paintMask()`](https://api.image-js.org/classes/index.Image.html#paintmask 'API link on paintMask')+ a `for` loop.
@@ -303,7 +303,7 @@ const matrix = getPerspectiveWarp(sourcePoints);
 const warped = img.transform(matrix);
 ```
 
-For more details, [visit our tutorial](/docs/Tutorials/Applying%20transform%20function%20on%20images 'internal link on transform function tutorial') on how image transformations work how they can be used.
+For more details, [visit our tutorial](../../docs/Tutorials/Applying%20transform%20function%20on%20images.md 'internal link on transform function tutorial') on how image transformations work how they can be used.
 
 ### Bicubic interpolation
 
@@ -323,11 +323,11 @@ const resized = img.resize(800, 600, { interpolation: 'bicubic' });
 const prewitt = img.derivative({ filter: 'prewitt' });
 ```
 
-**Use cases**: Object detection, image segmentation, feature extraction. You can [learn more about it here](../docs/Features/Morphology/Morphological%20Gradient 'internal link on morphological gradient').
+**Use cases**: Object detection, image segmentation, feature extraction. You can [learn more about it here](../../docs/Features/Morphology/Morphological%20Gradient.md 'internal link on morphological gradient').
 
 ### Migration from deprecated methods
 
-`warpingFourPoints()` has been removed. Now you have [`getPerspectiveWarp()`](../docs/Features/Geometry/Get%20Perspective%20Warp%20Matrix 'internal link on perspective warp') that returns a matrix that can be applied on the image of interest in a new `transform()`.
+`warpingFourPoints()` has been removed. Now you have [`getPerspectiveWarp()`](../../docs/Features/Geometry/Get%20Perspective%20Warp%20Matrix.md 'internal link on perspective warp') that returns a matrix that can be applied on the image of interest in a new `transform()`.
 
 ```ts
 // Before
@@ -338,7 +338,7 @@ const matrix = getPerspectiveWarp(corners);
 const warped = img.transform(matrix);
 ```
 
-**Use cases**: Rectification of a perspective angle of an image. You can learn more about it [here](../docs/Features/Geometry/Get%20Perspective%20Warp%20Matrix 'internal link on perspective warp').
+**Use cases**: Rectification of a perspective angle of an image. You can learn more about it [here](../../docs/Features/Geometry/Get%20Perspective%20Warp%20Matrix.md 'internal link on perspective warp').
 
 ### `merge()`
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -52,11 +52,6 @@ async function createConfig() {
     // For GitHub pages deployment, it is often '/<projectName>/'
     baseUrl: '/',
 
-    // GitHub pages deployment config.
-    // If you aren't using GitHub pages, you don't need these.
-    organizationName: 'Zakodium', // Usually your GitHub org/user name.
-    projectName: 'image-js', // Usually your repo name.
-
     plugins: [demoLoaderPlugin],
 
     onBrokenLinks: 'throw',
@@ -114,6 +109,14 @@ async function createConfig() {
         // Replace with your project's social card
         image: 'img/docusaurus-social-card.jpg',
         colorMode: {},
+        announcementBar: {
+          id: 'release-1.0',
+          content:
+            'ImageJS 1.0 has been released! <a href="/blog/releases/1.0">Click here</a> to read our announcement post.',
+          textColor: '#fff',
+          backgroundColor: '#1c4ed8',
+          isCloseable: true,
+        },
         navbar: {
           title: 'ImageJS',
           logo: {


### PR DESCRIPTION
I took inspiration from https://docusaurus.io/blog/releases/3.0 for the title and path.

Refs: https://docusaurus.io/docs/api/themes/configuration#announcement-bar
