### PR TITLE
chore: typo in getting-started.mdx

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -92,7 +92,7 @@ To load an image via a browser, you may use the `fetchURL` function:
 ```ts
 import { fetchURL } from 'image-js';
 
-let image = await fetchURL('https:://example.com/image.jpg');
+let image = await fetchURL('https://example.com/image.jpg');
 image = image.grey();
 ```
 


### PR DESCRIPTION
fix wrong url in example