### PR TITLE
style: improve readability for frontPage__text on smaller screens

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -119,3 +119,11 @@ button {
 .filter-demo-addon {
   max-width: 512px;
 }
+
+/* ===== Media queries ===== */
+
+@media (max-width: 768px) {
+  .frontPage__text {
+    max-width: 90%;
+  }
+}


### PR DESCRIPTION
This commit makes the text in the landing page more readable for smaller screens.

### Before

<img width="505" height="933" alt="image" src="https://github.com/user-attachments/assets/5c9e2fcc-3cf4-437b-bcd1-ba844bfcf6a6" />

### After

<img width="507" height="692" alt="image" src="https://github.com/user-attachments/assets/9fd9bac9-e4bd-49d4-81a3-802631db1459" />
